### PR TITLE
feat(eks): provisioning cluster

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,0 +1,21 @@
+name: Github action to create EKS cluster using eksctl 
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:    
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Run Shellcheck
+      uses: bewuethr/shellcheck-action@v2
+
+    - name: Configure AWS environment variables and start the workflow
+      run: make -k all
+      env:
+        ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        SECRET_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+    
+
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+all: | eks-install openebs-install openebs-uninstall eks-uninstall
+.PHONY: all
+eks-install: 
+	@cd eks && ./eks_install.sh
+openebs-install: 
+	@cd openebs && ./openebs_install.sh
+openebs-uninstall: 
+	@cd openebs && ./openebs_uninstall.sh
+eks-uninstall: 
+	@cd eks && ./eks_uninstall.sh
+
+

--- a/eks/cluster.yaml
+++ b/eks/cluster.yaml
@@ -1,0 +1,24 @@
+# This ClusterConfig object create 3 node aws cluster in same az: 
+---
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+metadata:
+#Cluster name      
+  name: dokc-cluster
+#Cluster will be created in ap-south-1 region. This region is selected since it has sufficient resources
+  region: ap-south-1
+
+nodeGroups:
+  - name: dokc-ng
+#Each node will have 4vcpu and 16GB RAM
+    instanceType: t3.xlarge 
+#All 3 nodes will be in ap-south-1a az
+    availabilityZones: ["ap-south-1a"] 
+# No. of nodes
+    desiredCapacity: 3 
+# Os volume size
+    volumeSize: 50 
+    iam:
+      withAddonPolicies:      
+# To give access to CSI driver
+        ebs: true 

--- a/eks/eks_install.sh
+++ b/eks/eks_install.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set +e
+echo -e "\nInstall the latest eksctl"
+curl --silent --location \
+"https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" \
+| tar xz -C /tmp
+sudo mv /tmp/eksctl /usr/local/bin
+eksctl version
+kubectl version --client
+
+echo -e "\nConfigure AWS credentials"
+aws configure set aws_access_key_id "$ACCESS_KEY"
+aws configure set aws_secret_access_key "$SECRET_KEY"
+aws configure set default.region "$REGION"
+
+echo -e "\nCreating AWS cluster"
+eksctl create cluster -f cluster.yaml
+
+echo -e "\nList of nodes in cluster"
+kubectl get nodes -owide

--- a/eks/eks_uninstall.sh
+++ b/eks/eks_uninstall.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+ 
+CLEAN=${CLEAN:-true}
+
+if [[ $CLEAN == true ]]; then
+
+    echo -e "\nCleaning up eks cluster."
+    echo -e "\nSet CLEAN=false if you wish for this not to occur."
+    eksctl delete cluster -f cluster.yaml
+
+    echo -e "\nList of clusters to verify cleanup process"
+    eksctl get cluster --region=ap-south-1
+fi

--- a/experiments/assert-kubesystem-pod.yaml
+++ b/experiments/assert-kubesystem-pod.yaml
@@ -1,0 +1,90 @@
+apiVersion: dope.mayadata.io/v1
+kind: Recipe
+metadata:
+  name: assert-kube-system-pod-running
+  namespace: d-testing
+  labels:
+    d-testing.dope.mayadata.io/inference: "true"
+spec:
+  tasks:
+
+  # Check aws node pod status
+  - name: assert-running-of-aws-node
+    assert:
+      stateCheck:
+        stateCheckOperator: ListCountEquals
+        count: 3
+      state:
+        kind: Pod
+        apiVersion: v1
+        metadata:
+          namespace: kube-system
+          labels:
+            k8s-app: aws-node
+        status:
+          phase: Running
+    
+  # Check coredns pod status
+  - name: assert-running-of-coredns
+    assert:
+      stateCheck:
+        stateCheckOperator: ListCountEquals
+        count: 2
+      state:
+        kind: Pod
+        apiVersion: v1
+        metadata:
+          namespace: kube-system
+          labels:
+            k8s-app: kube-dns
+        status:
+          phase: Running
+
+  # Check ebs-csi-controller pod status
+  - name: assert-running-of-ebs-csi-controller
+    assert:
+      stateCheck:
+        stateCheckOperator: ListCountEquals
+        count: 2
+      state:
+        kind: Pod
+        apiVersion: v1
+        metadata:
+          namespace: kube-system
+          labels:
+            app: ebs-csi-controller
+        status:
+          phase: Running
+
+  # Check ebs-csi-node pod status
+  - name: assert-running-of-ebs-csi-node
+    assert:
+      stateCheck:
+        stateCheckOperator: ListCountEquals
+        count: 3
+      state:
+        kind: Pod
+        apiVersion: v1
+        metadata:
+          namespace: kube-system
+          labels:
+            app: ebs-csi-node
+        status:
+          phase: Running
+
+  # Check kube-proxy pod status
+  - name: assert-running-of-kube-proxy
+    assert:
+      stateCheck:
+        stateCheckOperator: ListCountEquals
+        count: 3
+      state:
+        kind: Pod
+        apiVersion: v1
+        metadata:
+          namespace: kube-system
+          labels:
+            k8s-app: kube-proxy
+        status:
+          phase: Running
+    

--- a/experiments/assert-openebs-pod.yaml
+++ b/experiments/assert-openebs-pod.yaml
@@ -1,0 +1,122 @@
+apiVersion: dope.mayadata.io/v1
+kind: Recipe
+metadata:
+  name: assert-openebs-pod-running
+  namespace: d-testing
+  labels:
+    d-testing.dope.mayadata.io/inference: "true"
+spec:
+  tasks:
+
+  # Check maya-apiserver pod status
+  - name: assert-running-of-maya-apiserver
+    assert:
+      stateCheck:
+        stateCheckOperator: ListCountEquals
+        count: 1
+      state:
+        kind: Pod
+        apiVersion: v1
+        metadata:
+          namespace: openebs
+          labels:
+            name: maya-apiserver
+        status:
+          phase: Running
+    
+  # Check openebs-admission-server pod status
+  - name: assert-running-of-openebs-admission-server
+    assert:
+      stateCheck:
+        stateCheckOperator: ListCountEquals
+        count: 1
+      state:
+        kind: Pod
+        apiVersion: v1
+        metadata:
+          namespace: openebs
+          labels:
+            app: admission-webhook
+        status:
+          phase: Running
+
+  # Check openebs-localpv-provisioner pod status
+  - name: assert-running-of-openebs-localpv-provisioner
+    assert:
+      stateCheck:
+        stateCheckOperator: ListCountEquals
+        count: 1
+      state:
+        kind: Pod
+        apiVersion: v1
+        metadata:
+          namespace: openebs
+          labels:
+            name: openebs-localpv-provisioner
+        status:
+          phase: Running
+
+  # Check openebs-ndm pod status
+  - name: assert-running-of-openebs-ndm
+    assert:
+      stateCheck:
+        stateCheckOperator: ListCountEquals
+        count: 3
+      state:
+        kind: Pod
+        apiVersion: v1
+        metadata:
+          namespace: openebs
+          labels:
+            name: openebs-ndm
+        status:
+          phase: Running
+
+  # Check openebs-ndm-operator pod status
+  - name: assert-running-of-openebs-ndm-operator
+    assert:
+      stateCheck:
+        stateCheckOperator: ListCountEquals
+        count: 1
+      state:
+        kind: Pod
+        apiVersion: v1
+        metadata:
+          namespace: openebs
+          labels:
+            name: openebs-ndm-operator
+        status:
+          phase: Running
+    
+  # Check openebs-provisioner pod status
+  - name: assert-running-of-openebs-provisioner
+    assert:
+      stateCheck:
+        stateCheckOperator: ListCountEquals
+        count: 1
+      state:
+        kind: Pod
+        apiVersion: v1
+        metadata:
+          namespace: openebs
+          labels:
+            name: openebs-provisioner
+        status:
+          phase: Running
+
+  # Check openebs-snapshot-operator pod status
+  - name: assert-running-of-openebs-snapshot-operator
+    assert:
+      stateCheck:
+        stateCheckOperator: ListCountEquals
+        count: 1
+      state:
+        kind: Pod
+        apiVersion: v1
+        metadata:
+          namespace: openebs
+          labels:
+            name: openebs-snapshot-operator
+        status:
+          phase: Running
+    

--- a/experiments/ci.yml
+++ b/experiments/ci.yml
@@ -1,0 +1,120 @@
+# This yaml file demonstrates the use of Kubernetes
+# and few custom resources to build a custom CI 
+# framework. In this framework, Kubernetes is the CI
+# runner and custom resources are the test case 
+# implementations.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dope
+---
+# d-testing is the Kubernetes namespace that can
+# be used to deploy any test artifacts
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: d-testing
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+  name: recipes.dope.mayadata.io
+spec:
+  group: dope.mayadata.io
+  names:
+    kind: Recipe
+    listKind: RecipeList
+    plural: recipes
+    shortNames:
+    - rcp
+    singular: recipe
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  additionalPrinterColumns:
+  - name: Age
+    type: date
+    description: Age of this Recipe
+    JSONPath: .metadata.creationTimestamp
+  - name: TimeTaken
+    type: string
+    description: Time taken to execute this Recipe
+    JSONPath: .status.executionTime.readableValue
+  - name: Status
+    type: string
+    description: Current phase of this Recipe
+    JSONPath: .status.phase
+  - name: Reason
+    type: string
+    description: Description of this phase
+    JSONPath: .status.reason
+---
+# dope is the Kubernetes service account that has
+# all priviledges to manage any Kubernetes resources
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dope
+  namespace: dope
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dope
+rules:
+- apiGroups:
+  - "*"
+  resources:
+  - "*"
+  verbs:
+  - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dope
+subjects:
+- kind: ServiceAccount
+  name: dope
+  namespace: dope
+roleRef:
+  kind: ClusterRole
+  name: dope
+  apiGroup: rbac.authorization.k8s.io
+---
+# This StatefulSet deploys dope
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.mayadata.io/name: dope
+  name: dope
+  namespace: dope
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.mayadata.io/name: dope
+  serviceName: ""
+  template:
+    metadata:
+      labels:
+        app.mayadata.io/name: dope
+    spec:
+      serviceAccountName: dope
+      containers:
+      - name: dope
+        image: mayadataio/dope:v1.9.0
+        command: ["/usr/bin/dope"]
+        args:
+        - --logtostderr
+        - --run-as-local
+        - -v=1
+        - --discovery-interval=30s
+        - --cache-flush-interval=240s

--- a/experiments/inference.yaml
+++ b/experiments/inference.yaml
@@ -1,0 +1,88 @@
+# This is an internal recipe used by test suite runner
+# to evaluate if desired experiments (read Recipes) were
+# successful or not
+#
+# NOTE:
+#   This Recipe evaluates number of successful, failed &
+# errored Recipes
+apiVersion: dope.mayadata.io/v1
+kind: Recipe
+metadata:
+  name: inference
+  namespace: d-testing
+  labels:
+    d-testing.dope.mayadata.io/internal: "true"
+spec:
+  # This Recipe is eligible to run only when the checks succeed
+  #
+  # NOTE:
+  #   In this case, this Recipe will be eligible only after the
+  # number of Recipes with matching labels equal the given count
+  #
+  # NOTE:
+  #   Eligibility check will get triggered after above think time 
+  # has elapsed
+  eligible:
+    checks:
+    - labelSelector:
+        matchLabels:
+          d-testing.dope.mayadata.io/inference: "true"
+        matchExpressions:
+        - key: recipe.dope.mayadata.io/phase
+          operator: Exists
+        - key: recipe.dope.mayadata.io/phase
+          operator: NotIn
+          values: 
+          - NotEligible
+      when: ListCountEquals
+      count: 2
+  resync:
+    onNotEligibleResyncInSeconds: 5
+  tasks:
+  # Start with asserting the count of Recipes that should 
+  # complete successfully
+  - name: assert-count-of-tests-that-completed
+    assert: 
+      state: 
+        kind: Recipe
+        apiVersion: dope.mayadata.io/v1
+        metadata:
+          namespace: d-testing
+          labels:
+            d-testing.dope.mayadata.io/inference: "true"
+            recipe.dope.mayadata.io/phase: Completed
+      stateCheck:
+        stateCheckOperator: ListCountEquals
+        # These many Recipes should succeed
+        count: 2
+  # Then assert the count of Recipes that should fail
+  - name: assert-count-of-tests-that-failed
+    assert: 
+      state: 
+        kind: Recipe
+        apiVersion: dope.mayadata.io/v1
+        metadata:
+          namespace: d-testing
+          labels:
+            d-testing.dope.mayadata.io/inference: "true"
+            recipe.dope.mayadata.io/phase: Failed
+      stateCheck:
+        stateCheckOperator: ListCountEquals
+        # These many Recipes should fail
+        count: 0
+  # Then assert the count of Recipes that should error
+  - name: assert-count-of-tests-that-errored
+    assert: 
+      state: 
+        kind: Recipe
+        apiVersion: dope.mayadata.io/v1
+        metadata:
+          namespace: d-testing
+          labels:
+            d-testing.dope.mayadata.io/inference: "true"
+            recipe.dope.mayadata.io/phase: Error
+      stateCheck:
+        stateCheckOperator: ListCountEquals
+        # These many Recipes should error out
+        count: 0
+---

--- a/openebs/disk.yaml
+++ b/openebs/disk.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cassandra-disk1
+  namespace: disk
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ebs-sc
+  resources:
+    requests:
+      storage: 4Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cassandra-disk2
+  namespace: disk
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ebs-sc
+  resources:
+    requests:
+      storage: 4Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cassandra-disk3
+  namespace: disk
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ebs-sc
+  resources:
+    requests:
+      storage: 4Gi

--- a/openebs/openebs_install.sh
+++ b/openebs/openebs_install.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+set +e 
+
+echo -e "\nInstall Amazon EBS CSI driver"
+kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=master"
+sleep 10
+
+echo -e "\nInstall storage class"
+kubectl apply -f storageclass.yaml
+
+kubectl create ns disk
+echo -e "\nCreate pvc"
+kubectl apply -f disk.yaml 
+
+echo -e "\nList of pvc"
+kubectl get pvc -n disk
+
+echo -e "\nInstall openebs "
+kubectl apply -f https://openebs.github.io/charts/openebs-operator.yaml
+
+#Below yaml is used to verify the running status of kube-system and openebs pods
+kubectl apply -f ./../experiments/ci.yml
+kubectl apply -f ./../experiments/assert-kubesystem-pod.yaml
+kubectl apply -f ./../experiments/assert-openebs-pod.yaml
+kubectl apply -f ./../experiments/inference.yaml
+
+# group that defines the Recipe custom resource
+group="recipes.dope.mayadata.io"
+
+# Namespace used by inference Recipe custom resource
+ns="d-testing"
+echo -e "\n Retry 50 times until kube-system inference experiment gets executed"
+date
+phase=""
+for i in {1..50}
+do
+    phase=$(kubectl -n $ns get $group inference -o=jsonpath='{.status.phase}')
+    echo -e "Attempt $i: Inference status: status.phase='$phase'"
+    if [[ "$phase" == "" ]] || [[ "$phase" == "NotEligible" ]]; then
+        sleep 5 # Sleep & retry since experiment is in-progress
+    else
+        break # Abandon this loop since phase is set
+    fi
+done
+date
+
+if [[ "$phase" != "Completed" ]]; then
+    echo ""
+    echo "--------------------------"
+    echo -e "\npods are not running: status.phase='$phase'"
+    echo "--------------------------"
+    exit 1 # error since inference experiment did not succeed
+fi
+
+echo -e "\npods are running"
+
+echo -e "\nList all pods in kube-system namespaces"
+kubectl get pod -n kube-system
+
+echo -e "\nList of pods in openebs namespace"
+kubectl get po -n openebs
+
+echo -e "\nList of storage class"
+kubectl get sc
+
+echo -e "\nCreate volumeattachment directory"
+mkdir -p .tmp/volumeattachment
+
+echo -e "\nInstall volumeattachment"
+chmod +x volumeattachment.sh 
+./volumeattachment.sh
+
+echo -e "\nApply the volumeattachment yaml"
+kubectl apply -f .tmp/volumeattachment/ 
+
+kubectl get bd -n openebs
+
+echo -e "\nCheck the block devices"
+kubectl get bd -n openebs
+

--- a/openebs/openebs_uninstall.sh
+++ b/openebs/openebs_uninstall.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+ 
+CLEAN=${CLEAN:-true}
+
+if [[ $CLEAN == true ]]; then
+
+    echo -e "\nSet CLEAN=false if you wish for this not to occur."
+    echo -e "\nCleaning up OpenEBS components"
+    echo -e "\nDelete volumeattachment"
+    kubectl delete -f .tmp/volumeattachment/
+
+    echo -e "\nDelete the block devices"
+    kubectl delete bd -n openebs --all
+
+    echo -e "\nDelete the volumeattachment directory"
+    rm -rf .tmp/
+
+    echo -e "\nDelete openebs "
+    kubectl delete -f https://openebs.github.io/charts/openebs-operator.yaml
+    
+    echo -e "\nDelete disks"
+    kubectl delete -f disk.yaml
+    
+    kubectl delete ns disk
+
+    echo -e "\nDelete storage class"
+    kubectl delete -f storageclass.yaml
+
+    echo -e "\nDelete the csi driver"
+    kubectl delete -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=master"
+fi

--- a/openebs/storageclass.yaml
+++ b/openebs/storageclass.yaml
@@ -1,0 +1,7 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: ebs-sc
+provisioner: ebs.csi.aws.com
+# Immediate volume binding mode is used to have the PVC bounded once it's been created
+volumeBindingMode: Immediate

--- a/openebs/volumeattachment.sh
+++ b/openebs/volumeattachment.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -x
+
+#It gives the output of nodes in array format eg: ip-192-168-35-218.ap-south-1.compute.internal ip-192-168-36-249.ap-south-1.compute.internal ip-192-168-59-253.ap-south-1#.compute.internal
+IFS=" " read -r -a nodes <<< "$( kubectl get node -o jsonpath="{.items[*].metadata.name}" )"
+#It gives the output of pv in array format eg: pvc-313919eb-4fbd-40a0-ac03-d2a06c0979dd pvc-55de549c-499f-4074-ba4f-99455e9a02df pvc-f62c9516-0711-402f-82c8-773d31dd3#07c
+IFS=" " read -r -a pvs <<< "$( kubectl get pv -o jsonpath="{.items[*].metadata.name}" )"
+
+for (( i=0; i<${#nodes[@]}; i++ )); do
+    echo "${nodes[i]} and ${pvs[i]}"
+    cp volumeattachment_template.yaml .tmp/volumeattachment/volumeattachment"${i}".yaml
+    sed  "s/nodeName:.*$/nodeName: ${nodes[i]}/g" -i .tmp/volumeattachment/volumeattachment"${i}".yaml
+    sed  "s/persistentVolumeName:.*$/persistentVolumeName: ${pvs[i]}/g" -i .tmp/volumeattachment/volumeattachment"${i}".yaml
+    sed  "s/name:.*$/name: csi-vol${i}/g" -i .tmp/volumeattachment/volumeattachment"${i}".yaml
+done
+
+

--- a/openebs/volumeattachment_template.yaml
+++ b/openebs/volumeattachment_template.yaml
@@ -1,0 +1,14 @@
+#This template is used to create block device which will be attached to all the 3 nodes
+--- 
+apiVersion: storage.k8s.io/v1
+kind: VolumeAttachment
+metadata: 
+#volumesattachment name will be set by volumeattachment.sh script
+  name: 
+spec: 
+  attacher: ebs.csi.aws.com
+#Node name will be set by volumeattachment.sh script
+  nodeName: 
+  source: 
+#persistent volume name will be set by volumeattachment.sh script
+    persistentVolumeName: 


### PR DESCRIPTION
This commit adds github actions file which performs the following:

1. Install eksctl
2. Configure AWS credentials from secrets
3. Create EKS cluster using eksctl
4. Install OpenEBS
5. Install csi driver
6. Attach csi volume as a block device to nodes.
7. Use csi volume as an ebs disk.

****Folder** structure**
```
continuous-kubernetes/
├── eks
│   ├── cluster.yaml
│   ├── eks_install.sh
│   └── eks_uninstall.sh
├── experiments
│   ├── assert-kubesystem-pod.yaml
│   ├── assert-openebs-pod.yaml
│   ├── ci.yml
│   └── inference.yaml
├── LICENSE
├── Makefile
├── openebs
│   ├── disk.yaml
│   ├── openebs_install.sh
│   ├── openebs_uninstall.sh
│   ├── storageclass.yaml
│   ├── volumeattachment.sh
│   └── volumeattachment_template.yaml
└── README.md
```
Build log
[logs_19.zip](https://github.com/dokc/continuous-kubernetes/files/5210281/logs_19.zip)

  