### PR TITLE
feat(install):deploy cassandra on eks using kudo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,17 @@
-all: | eks-install openebs-install openebs-uninstall eks-uninstall
+all: | eks-install openebs-install kudo-install cassandra-install cassandra-uninstall kudo-uninstall openebs-uninstall eks-uninstall
 .PHONY: all
 eks-install: 
 	@cd eks && ./eks_install.sh
 openebs-install: 
 	@cd openebs && ./openebs_install.sh
+kudo-install: 
+	@cd kudo-operator && ./kudo_install.sh
+cassandra-install: 
+	@cd cassandra-scale && ./cassandra_install.sh
+cassandra-uninstall: 
+	@cd cassandra-scale && ./cassandra_uninstall.sh
+kudo-uninstall: 
+	@cd kudo-operator && ./kudo_uninstall.sh
 openebs-uninstall: 
 	@cd openebs && ./openebs_uninstall.sh
 eks-uninstall: 

--- a/cassandra-scale/cassandra_install.sh
+++ b/cassandra-scale/cassandra_install.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set +e
+
+echo -e "\nSet instances and namespace variables"
+export instance_name=cassandra-openebs
+export namespace_name=cassandra
+
+echo -e "\nCreate cassandra namespace"
+kubectl create ns cassandra
+
+echo -e "\nInstall cassandra operator with kudo"
+kubectl kudo install cassandra --namespace=$namespace_name --instance $instance_name -p NODE_STORAGE_CLASS=openebs-device
+sleep 25
+
+#Below yaml is used to check the running status of cassandra pods
+kubectl apply -f ./../experiments/assert-cassandra-pod.yaml
+kubectl apply -f ./../experiments/cassandra-inference.yaml
+
+# group that defines the Recipe custom resource
+group="recipes.dope.mayadata.io"
+
+# Namespace used by inference Recipe custom resource
+ns="d-testing"
+echo -e "\nRetry 50 times until cassandra inference experiment gets executed"
+date
+phase=""
+for i in {1..50}
+do
+    phase=$(kubectl -n $ns get $group cassandra-inference -o=jsonpath='{.status.phase}')
+    echo -e "Attempt $i: cassandra Inference status: status.phase='$phase'"
+    if [[ "$phase" == "" ]] || [[ "$phase" == "NotEligible" ]]; then
+        sleep 5 # Sleep & retry since experiment is in-progress
+    else
+        break # Abandon this loop since phase is set
+    fi
+done
+date
+
+if [[ "$phase" != "Completed" ]]; then
+    echo ""
+    echo "--------------------------"
+    echo -e "\npods are not running: status.phase='$phase'"
+    echo "--------------------------"
+fi
+
+echo -e "\nCassandra pods are running"
+
+echo -e "\nVerify cassandra pod status"
+kubectl get pod -n cassandra
+
+echo -e "\nVerify cassandra sts status"
+kubectl get sts -n cassandra
+
+
+
+
+
+

--- a/cassandra-scale/cassandra_install.sh
+++ b/cassandra-scale/cassandra_install.sh
@@ -10,7 +10,7 @@ kubectl create ns cassandra
 
 echo -e "\nInstall cassandra operator with kudo"
 kubectl kudo install cassandra --namespace=$namespace_name --instance $instance_name -p NODE_STORAGE_CLASS=openebs-device
-sleep 35
+sleep 45
 
 #Below yaml is used to check the running status of cassandra pods
 kubectl apply -f ./../experiments/assert-cassandra-pod.yaml
@@ -50,6 +50,11 @@ kubectl get pod -n cassandra
 
 echo -e "\nVerify cassandra sts status"
 kubectl get sts -n cassandra
+
+echo ""
+echo "--------------------------"
+echo "++ E to E suite passed"
+echo "--------------------------"
 
 
 

--- a/cassandra-scale/cassandra_install.sh
+++ b/cassandra-scale/cassandra_install.sh
@@ -10,7 +10,7 @@ kubectl create ns cassandra
 
 echo -e "\nInstall cassandra operator with kudo"
 kubectl kudo install cassandra --namespace=$namespace_name --instance $instance_name -p NODE_STORAGE_CLASS=openebs-device
-sleep 25
+sleep 35
 
 #Below yaml is used to check the running status of cassandra pods
 kubectl apply -f ./../experiments/assert-cassandra-pod.yaml

--- a/cassandra-scale/cassandra_uninstall.sh
+++ b/cassandra-scale/cassandra_uninstall.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set +e
+
+echo -e "\nSet instances and namespace variables"
+export instance_name=cassandra-openebs
+export namespace_name=cassandra
+
+echo -e "\nUninstalling cassandra from cluster"
+kubectl kudo uninstall --namespace=$namespace_name --instance $instance_name
+
+echo -e "\nTo delete cassandra pvc"
+kubectl delete pvc -n cassandra --all
+
+echo -e "\nDelete cassandra namespace"
+kubectl delete ns cassandra
+
+echo -e "\nCheck the bdc status"
+kubectl get bdc -n openebs

--- a/experiments/assert-cassandra-pod.yaml
+++ b/experiments/assert-cassandra-pod.yaml
@@ -1,0 +1,26 @@
+apiVersion: dope.mayadata.io/v1
+kind: Recipe
+metadata:
+  name: assert-cassandra-pod-running
+  namespace: d-testing
+  labels:
+    d-testing.dope.mayadata.io/cassandra-inference: "true"
+spec:
+  tasks:
+
+  # Check cassandra openebs node pod status
+  - name: assert-if-cassandra-openebs-node-is-running
+    assert:
+      stateCheck:
+        stateCheckOperator: ListCountEquals
+        count: 3
+      state:
+        kind: Pod
+        apiVersion: v1
+        metadata:
+          namespace: cassandra
+          labels:
+            app: cassandra-openebs
+        status:
+          phase: Running
+    

--- a/experiments/assert-cert-manger-pod.yaml
+++ b/experiments/assert-cert-manger-pod.yaml
@@ -1,0 +1,57 @@
+apiVersion: dope.mayadata.io/v1
+kind: Recipe
+metadata:
+  name: assert-cert-manager-pod-running
+  namespace: d-testing
+  labels:
+    d-testing.dope.mayadata.io/certmanager-inference: "true"
+spec:
+  tasks:
+
+  # Check cert manager pod status
+  - name: assert-if-cert-manager-is-running
+    assert:
+      stateCheck:
+        stateCheckOperator: ListCountEquals
+        count: 1
+      state:
+        kind: Pod
+        apiVersion: v1
+        metadata:
+          namespace: cert-manager
+          labels:
+            app: cert-manager
+        status:
+          phase: Running
+    
+  # Check cert manager cainjector pod status
+  - name: assert-if-cert-manager-cainjector-is-running
+    assert:
+      stateCheck:
+        stateCheckOperator: ListCountEquals
+        count: 1
+      state:
+        kind: Pod
+        apiVersion: v1
+        metadata:
+          namespace: cert-manager
+          labels:
+            app: cainjector
+        status:
+          phase: Running
+
+  # Check cert manager webhook pod status
+  - name: assert-if-cert-manager-webhook-is-running
+    assert:
+      stateCheck:
+        stateCheckOperator: ListCountEquals
+        count: 1
+      state:
+        kind: Pod
+        apiVersion: v1
+        metadata:
+          namespace: cert-manager
+          labels:
+            app: webhook
+        status:
+          phase: Running

--- a/experiments/assert-kubesystem-pod.yaml
+++ b/experiments/assert-kubesystem-pod.yaml
@@ -9,7 +9,7 @@ spec:
   tasks:
 
   # Check aws node pod status
-  - name: assert-running-of-aws-node
+  - name: assert-if-aws-node-is-running
     assert:
       stateCheck:
         stateCheckOperator: ListCountEquals
@@ -25,7 +25,7 @@ spec:
           phase: Running
     
   # Check coredns pod status
-  - name: assert-running-of-coredns
+  - name: assert-if-coredns-is-running
     assert:
       stateCheck:
         stateCheckOperator: ListCountEquals
@@ -41,7 +41,7 @@ spec:
           phase: Running
 
   # Check ebs-csi-controller pod status
-  - name: assert-running-of-ebs-csi-controller
+  - name: assert-if-ebs-csi-controller-is-running
     assert:
       stateCheck:
         stateCheckOperator: ListCountEquals
@@ -57,7 +57,7 @@ spec:
           phase: Running
 
   # Check ebs-csi-node pod status
-  - name: assert-running-of-ebs-csi-node
+  - name: assert-if-ebs-csi-node-is-running
     assert:
       stateCheck:
         stateCheckOperator: ListCountEquals
@@ -73,7 +73,7 @@ spec:
           phase: Running
 
   # Check kube-proxy pod status
-  - name: assert-running-of-kube-proxy
+  - name: assert-if-kube-proxy-is-running
     assert:
       stateCheck:
         stateCheckOperator: ListCountEquals

--- a/experiments/assert-openebs-pod.yaml
+++ b/experiments/assert-openebs-pod.yaml
@@ -9,7 +9,7 @@ spec:
   tasks:
 
   # Check maya-apiserver pod status
-  - name: assert-running-of-maya-apiserver
+  - name: assert-if-maya-apiserver-is-running
     assert:
       stateCheck:
         stateCheckOperator: ListCountEquals
@@ -25,7 +25,7 @@ spec:
           phase: Running
     
   # Check openebs-admission-server pod status
-  - name: assert-running-of-openebs-admission-server
+  - name: assert-if-openebs-admission-server-is-running
     assert:
       stateCheck:
         stateCheckOperator: ListCountEquals
@@ -41,7 +41,7 @@ spec:
           phase: Running
 
   # Check openebs-localpv-provisioner pod status
-  - name: assert-running-of-openebs-localpv-provisioner
+  - name: assert-if-openebs-localpv-provisioner-is-running
     assert:
       stateCheck:
         stateCheckOperator: ListCountEquals
@@ -57,7 +57,7 @@ spec:
           phase: Running
 
   # Check openebs-ndm pod status
-  - name: assert-running-of-openebs-ndm
+  - name: assert-if-openebs-ndm-is-running
     assert:
       stateCheck:
         stateCheckOperator: ListCountEquals
@@ -73,7 +73,7 @@ spec:
           phase: Running
 
   # Check openebs-ndm-operator pod status
-  - name: assert-running-of-openebs-ndm-operator
+  - name: assert-if-openebs-ndm-operator-is-running
     assert:
       stateCheck:
         stateCheckOperator: ListCountEquals
@@ -89,7 +89,7 @@ spec:
           phase: Running
     
   # Check openebs-provisioner pod status
-  - name: assert-running-of-openebs-provisioner
+  - name: assert-if-openebs-provisioner-is-running
     assert:
       stateCheck:
         stateCheckOperator: ListCountEquals
@@ -105,7 +105,7 @@ spec:
           phase: Running
 
   # Check openebs-snapshot-operator pod status
-  - name: assert-running-of-openebs-snapshot-operator
+  - name: assert-if-openebs-snapshot-operator-is-running
     assert:
       stateCheck:
         stateCheckOperator: ListCountEquals

--- a/experiments/cassandra-inference.yaml
+++ b/experiments/cassandra-inference.yaml
@@ -1,0 +1,88 @@
+# This is an internal recipe used by test suite runner
+# to evaluate if desired experiments (read Recipes) were
+# successful or not
+#
+# NOTE:
+#   This Recipe evaluates number of successful, failed &
+# errored Recipes
+apiVersion: dope.mayadata.io/v1
+kind: Recipe
+metadata:
+  name: cassandra-inference
+  namespace: d-testing
+  labels:
+    d-testing.dope.mayadata.io/internal: "true"
+spec:
+  # This Recipe is eligible to run only when the checks succeed
+  #
+  # NOTE:
+  #   In this case, this Recipe will be eligible only after the
+  # number of Recipes with matching labels equal the given count
+  #
+  # NOTE:
+  #   Eligibility check will get triggered after above think time 
+  # has elapsed
+  eligible:
+    checks:
+    - labelSelector:
+        matchLabels:
+          d-testing.dope.mayadata.io/cassandra-inference: "true"
+        matchExpressions:
+        - key: recipe.dope.mayadata.io/phase
+          operator: Exists
+        - key: recipe.dope.mayadata.io/phase
+          operator: NotIn
+          values: 
+          - NotEligible
+      when: ListCountEquals
+      count: 1
+  resync:
+    onNotEligibleResyncInSeconds: 5
+  tasks:
+  # Start with asserting the count of Recipes that should 
+  # complete successfully
+  - name: assert-count-of-tests-that-completed
+    assert: 
+      state: 
+        kind: Recipe
+        apiVersion: dope.mayadata.io/v1
+        metadata:
+          namespace: d-testing
+          labels:
+            d-testing.dope.mayadata.io/cassandra-inference: "true"
+            recipe.dope.mayadata.io/phase: Completed
+      stateCheck:
+        stateCheckOperator: ListCountEquals
+        # These many Recipes should succeed
+        count: 1
+  # Then assert the count of Recipes that should fail
+  - name: assert-count-of-tests-that-failed
+    assert: 
+      state: 
+        kind: Recipe
+        apiVersion: dope.mayadata.io/v1
+        metadata:
+          namespace: d-testing
+          labels:
+            d-testing.dope.mayadata.io/cassandra-inference: "true"
+            recipe.dope.mayadata.io/phase: Failed
+      stateCheck:
+        stateCheckOperator: ListCountEquals
+        # These many Recipes should fail
+        count: 0
+  # Then assert the count of Recipes that should error
+  - name: assert-count-of-tests-that-errored
+    assert: 
+      state: 
+        kind: Recipe
+        apiVersion: dope.mayadata.io/v1
+        metadata:
+          namespace: d-testing
+          labels:
+            d-testing.dope.mayadata.io/cassandra-inference: "true"
+            recipe.dope.mayadata.io/phase: Error
+      stateCheck:
+        stateCheckOperator: ListCountEquals
+        # These many Recipes should error out
+        count: 0
+---

--- a/experiments/cert-manager-inference.yaml
+++ b/experiments/cert-manager-inference.yaml
@@ -1,0 +1,88 @@
+# This is an internal recipe used by test suite runner
+# to evaluate if desired experiments (read Recipes) were
+# successful or not
+#
+# NOTE:
+#   This Recipe evaluates number of successful, failed &
+# errored Recipes
+apiVersion: dope.mayadata.io/v1
+kind: Recipe
+metadata:
+  name: certmanager-inference
+  namespace: d-testing
+  labels:
+    d-testing.dope.mayadata.io/internal: "true"
+spec:
+  # This Recipe is eligible to run only when the checks succeed
+  #
+  # NOTE:
+  #   In this case, this Recipe will be eligible only after the
+  # number of Recipes with matching labels equal the given count
+  #
+  # NOTE:
+  #   Eligibility check will get triggered after above think time 
+  # has elapsed
+  eligible:
+    checks:
+    - labelSelector:
+        matchLabels:
+          d-testing.dope.mayadata.io/certmanager-inference: "true"
+        matchExpressions:
+        - key: recipe.dope.mayadata.io/phase
+          operator: Exists
+        - key: recipe.dope.mayadata.io/phase
+          operator: NotIn
+          values: 
+          - NotEligible
+      when: ListCountEquals
+      count: 1
+  resync:
+    onNotEligibleResyncInSeconds: 5
+  tasks:
+  # Start with asserting the count of Recipes that should 
+  # complete successfully
+  - name: assert-count-of-tests-that-completed
+    assert: 
+      state: 
+        kind: Recipe
+        apiVersion: dope.mayadata.io/v1
+        metadata:
+          namespace: d-testing
+          labels:
+            d-testing.dope.mayadata.io/certmanager-inference: "true"
+            recipe.dope.mayadata.io/phase: Completed
+      stateCheck:
+        stateCheckOperator: ListCountEquals
+        # These many Recipes should succeed
+        count: 1
+  # Then assert the count of Recipes that should fail
+  - name: assert-count-of-tests-that-failed
+    assert: 
+      state: 
+        kind: Recipe
+        apiVersion: dope.mayadata.io/v1
+        metadata:
+          namespace: d-testing
+          labels:
+            d-testing.dope.mayadata.io/certmanager-inference: "true"
+            recipe.dope.mayadata.io/phase: Failed
+      stateCheck:
+        stateCheckOperator: ListCountEquals
+        # These many Recipes should fail
+        count: 0
+  # Then assert the count of Recipes that should error
+  - name: assert-count-of-tests-that-errored
+    assert: 
+      state: 
+        kind: Recipe
+        apiVersion: dope.mayadata.io/v1
+        metadata:
+          namespace: d-testing
+          labels:
+            d-testing.dope.mayadata.io/certmanager-inference: "true"
+            recipe.dope.mayadata.io/phase: Error
+      stateCheck:
+        stateCheckOperator: ListCountEquals
+        # These many Recipes should error out
+        count: 0
+---

--- a/experiments/ci.yml
+++ b/experiments/ci.yml
@@ -110,7 +110,7 @@ spec:
       serviceAccountName: dope
       containers:
       - name: dope
-        image: mayadataio/dope:v1.9.0
+        image: mayadataio/dope:v1.10.0
         command: ["/usr/bin/dope"]
         args:
         - --logtostderr

--- a/kudo-operator/kudo_install.sh
+++ b/kudo-operator/kudo_install.sh
@@ -27,6 +27,7 @@ kubectl-kudo version
 
 echo -e "\nVerify cert-manager is installed"
 kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.0.1/cert-manager.yaml
+sleep 20
 
 #Below yaml is used to check the running status of certmanager pods
 kubectl apply -f ./../experiments/assert-cert-manger-pod.yaml

--- a/kudo-operator/kudo_install.sh
+++ b/kudo-operator/kudo_install.sh
@@ -8,8 +8,8 @@ export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
 
 echo -e "\nVerify that go utility had been set"
 echo $GOROOT
-echo $GOPATH
-echo $PATH
+echo "$GOPATH"
+echo "$PATH"
 
 echo -e "\nDownload kudo operator 0.14.0"
 VERSION=0.14.0

--- a/kudo-operator/kudo_install.sh
+++ b/kudo-operator/kudo_install.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+set +e
+
+echo -e "\nSetting up go utlility"
+export GOROOT=/usr/local/go
+export GOPATH=$HOME/gopath
+export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+
+echo -e "\nVerify that go utility had been set"
+echo $GOROOT
+echo $GOPATH
+echo $PATH
+
+echo -e "\nDownload kudo operator 0.14.0"
+VERSION=0.14.0
+OS=$(uname | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+wget -O kubectl-kudo https://github.com/kudobuilder/kudo/releases/download/v${VERSION}/kubectl-kudo_${VERSION}_"${OS}"_"${ARCH}"
+chmod +x kubectl-kudo
+
+echo -e "\nAdd kubectl kudo to path"
+sudo mv kubectl-kudo /usr/local/bin/kubectl-kudo
+
+echo -e "\nVerify kudo cli is installed"
+kubectl-kudo version
+
+echo -e "\nVerify cert-manager is installed"
+kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.0.1/cert-manager.yaml
+
+#Below yaml is used to check the running status of certmanager pods
+kubectl apply -f ./../experiments/assert-cert-manger-pod.yaml
+kubectl apply -f ./../experiments/cert-manager-inference.yaml
+
+# group that defines the Recipe custom resource
+group="recipes.dope.mayadata.io"
+
+# Namespace used by inference Recipe custom resource
+ns="d-testing"
+echo -e "\nRetry 50 times until certmanager inference experiment gets executed"
+date
+phase=""
+for i in {1..50}
+do
+    phase=$(kubectl -n $ns get $group certmanager-inference -o=jsonpath='{.status.phase}')
+    echo -e "Attempt $i: certmanager Inference status: status.phase='$phase'"
+    if [[ "$phase" == "" ]] || [[ "$phase" == "NotEligible" ]]; then
+        sleep 5 # Sleep & retry since experiment is in-progress
+    else
+        break # Abandon this loop since phase is set
+    fi
+done
+date
+
+if [[ "$phase" != "Completed" ]]; then
+    echo ""
+    echo "--------------------------"
+    echo -e "\npods are not running: status.phase='$phase'"
+    echo "--------------------------"
+    exit 1 # error since inference experiment did not succeed
+fi
+
+echo -e "\ncert-manager pods are running"
+kubectl get pod -n cert-manager
+
+echo -e "\nInstalling kudo in cluster"
+kubectl-kudo init --version 0.14.0
+sleep 20
+
+echo -e "\nVerify kudo-system namespace"
+kubectl get pod -n kudo-system
+
+
+
+
+
+
+

--- a/kudo-operator/kudo_uninstall.sh
+++ b/kudo-operator/kudo_uninstall.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set +e
+
+echo -e "\nUninstalling kudo from cluster"
+kubectl kudo init --dry-run --output yaml | kubectl delete -f -
+
+echo -e "\nTo verify kudo had been removed from the cluster"
+kubectl get -n kudo-system pod
+
+echo -e "\nUninstall cert-manager"
+kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v1.0.1/cert-manager.yaml

--- a/kudo-operator/kudo_uninstall.sh
+++ b/kudo-operator/kudo_uninstall.sh
@@ -7,5 +7,3 @@ kubectl kudo init --dry-run --output yaml | kubectl delete -f -
 echo -e "\nTo verify kudo had been removed from the cluster"
 kubectl get -n kudo-system pod
 
-echo -e "\nUninstall cert-manager"
-kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v1.0.1/cert-manager.yaml

--- a/openebs/disk.yaml
+++ b/openebs/disk.yaml
@@ -9,7 +9,7 @@ spec:
   storageClassName: ebs-sc
   resources:
     requests:
-      storage: 4Gi
+      storage: 24Gi
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -22,7 +22,7 @@ spec:
   storageClassName: ebs-sc
   resources:
     requests:
-      storage: 4Gi
+      storage: 24Gi
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -35,4 +35,4 @@ spec:
   storageClassName: ebs-sc
   resources:
     requests:
-      storage: 4Gi
+      storage: 24Gi

--- a/openebs/openebs_uninstall.sh
+++ b/openebs/openebs_uninstall.sh
@@ -9,6 +9,9 @@ if [[ $CLEAN == true ]]; then
     echo -e "\nDelete volumeattachment"
     kubectl delete -f .tmp/volumeattachment/
 
+    echo -e "\nverify all bd are in unclaim state"
+    kubectl get bd -n openebs
+
     echo -e "\nDelete the block devices"
     kubectl delete bd -n openebs --all
 


### PR DESCRIPTION
## Description

- This PR intends to do the below things:

1. Install eksctl
2. Configure AWS credentials from secrets
3. Create EKS cluster using eksctl
4. Install OpenEBS
5. Install csi driver
6. Attach csi volume as a block device to nodes.
7. Use csi volume as an ebs disk.
8. Deploy Kudo operator
9. Use kudo operator to deploy Cassandra. Storage class used is openebs-device
10. Uninstall and teardown the cluster

****Folder** structure**
```
continuous-kubernetes/
├── cassandra-scale
│   ├── cassandra_install.sh
│   └── cassandra_uninstall.sh
├── eks
│   ├── cluster.yaml
│   ├── eks_install.sh
│   └── eks_uninstall.sh
├── experiments
│   ├── assert-cassandra-pod.yaml
│   ├── assert-cert-manger-pod.yaml
│   ├── assert-kubesystem-pod.yaml
│   ├── assert-openebs-pod.yaml
│   ├── cassandra-inference.yaml
│   ├── cert-manager-inference.yaml
│   ├── ci.yml
│   └── inference.yaml
├── kudo-operator
│   ├── kudo_install.sh
│   └── kudo_uninstall.sh
├── LICENSE
├── Makefile
├── openebs
│   ├── disk.yaml
│   ├── openebs_install.sh
│   ├── openebs_uninstall.sh
│   ├── storageclass.yaml
│   ├── volumeattachment.sh
│   └── volumeattachment_template.yaml
└── README.md

```
Build log
[logs_25.zip](https://github.com/dokc/continuous-kubernetes/files/5246838/logs_25.zip)

